### PR TITLE
Extended format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Logstash plugin for Amazon DynamoDB gives you a nearly real-time view of the
 
 Logstash is a data pipeline service that processes data, parses data, and then outputs it to a selected location in a selected format. Elasticsearch is a distributed, full-text search server. For more information about Logstash and Elasticsearch, go to https://www.elastic.co/products/elasticsearch.
 
+**NOTICE**: This plugin is compatible with Logstash up to version 2.4.
+
 ## The following sections walk you through the process to:
 
 1. Create a DynamoDB table and enable a new stream on the table.
@@ -179,7 +181,7 @@ perform_stream | Boolean option to not automatically stream new data into Logsta
 read_ops  | Number of read operations per second to perform when scanning the specified table.
 number_of_scan_threads | Number of threads to use when scanning the specified table.
 number_of_write_threads | Number of threads to write to the Logstash queue when scanning the table.
-log_format | Log transfer format. "plain" - Returns the object as a DynamoDB object. "json_drop_binary" - Translates the item format to JSON and drops any binary attributes. "json_binary_as_text" - Translates the item format to JSON and represents any binary attributes as 64-bit encoded binary strings. For more information, see the JSON Data Format topic in the DynamoDB documentation.
+log_format | Log transfer format. "plain" - Returns the object as a DynamoDB object. "json_drop_binary" - Translates the item format to JSON and drops any binary attributes. "json_binary_as_text" - Translates the item format to JSON and represents any binary attributes as 64-bit encoded binary strings. "extended" - Returns a parsed object, regardless of view_type. For more information, see the JSON Data Format topic in the DynamoDB documentation.
 
 ### Testing the Logstash Plugin for Amazon DynamoDB
 

--- a/lib/logstash/inputs/DynamoDBLogParser.rb
+++ b/lib/logstash/inputs/DynamoDBLogParser.rb
@@ -98,12 +98,25 @@ module Logstash
           if @log_format == LogStash::Inputs::DynamoDB::LF_PLAIN
             return hash.to_json
           end
+          if @log_format == LogStash::Inputs::DynamoDB::LF_EXTENDED
+            result = hash.clone
+            %w(keys oldImage newImage).each do |field|
+              unless hash["dynamodb"][field].nil?
+                result[field] = formatAttributeValueMap(hash["dynamodb"][field])
+              end
+            end
+            result.delete "dynamodb"
+            return result.to_json
+          end
           case @view_type
           when LogStash::Inputs::DynamoDB::VT_KEYS_ONLY
             return parse_format(hash["dynamodb"]["keys"])
           when LogStash::Inputs::DynamoDB::VT_OLD_IMAGE
             return parse_format(hash["dynamodb"]["oldImage"])
           when LogStash::Inputs::DynamoDB::VT_NEW_IMAGE
+             if hash["eventName"] == "REMOVE"
+                return parse_format(hash["dynamodb"]["keys"])
+              end
             return parse_format(hash["dynamodb"]["newImage"]) #check new and old, dynamodb.
           end
         end
@@ -132,7 +145,7 @@ module Logstash
               keys_to_delete.push(k) # remove binary values and binary sets
               next
             end
-            hash[k] = formatAttributeValue(v.keys.first, v.values.first)
+            hash[k] = formatAttributeValue(dynamodb_key, dynamodb_value)
           end
           keys_to_delete.each {|key| hash.delete(key)}
           return hash

--- a/lib/logstash/inputs/DynamoDBLogParser.rb
+++ b/lib/logstash/inputs/DynamoDBLogParser.rb
@@ -32,9 +32,10 @@ module Logstash
 
         MAX_NUMBER_OF_BYTES_FOR_NUMBER = 21;
 
-        def initialize(view_type, log_format, key_schema, region)
+        def initialize(view_type, log_format, key_schema, region, table_name)
           @view_type = view_type
           @log_format = log_format
+          @table_name = table_name
           @mapper ||= ObjectMapper.new()
           @mapper.setSerializationInclusion(JsonInclude::Include::NON_NULL)
           @mapper.addMixInAnnotations(AttributeValue, AttributeValueMixIn);
@@ -106,6 +107,7 @@ module Logstash
               end
             end
             result.delete "dynamodb"
+            result['tableName'] = @table_name
             return result.to_json
           end
           case @view_type

--- a/lib/logstash/inputs/dynamodb.rb
+++ b/lib/logstash/inputs/dynamodb.rb
@@ -152,7 +152,7 @@ class LogStash::Inputs::DynamoDB < LogStash::Inputs::Base
     if @perform_scan and @view_type == VT_OLD_IMAGE
       raise(LogStash::ConfigurationError, "Cannot perform scan with view type: " + @view_type + " configuration")
     end
-    if @view_type == VT_ALL_IMAGES and !(@log_format == LF_PLAIN)
+    if @view_type == VT_ALL_IMAGES and ![LF_PLAIN, LF_EXTENDED].include?(@log_format)
       raise(LogStash::ConfigurationError, "Cannot show view_type: " + @view_type + ", with log_format: " + @log_format)
     end
 

--- a/lib/logstash/inputs/dynamodb.rb
+++ b/lib/logstash/inputs/dynamodb.rb
@@ -61,10 +61,11 @@ class LogStash::Inputs::DynamoDB < LogStash::Inputs::Base
 
   USER_AGENT = " logstash-input-dynamodb/1.0.0".freeze
 
-  LF_DYNAMODB = "dymamodb".freeze
+  LF_DYNAMODB = "dynamodb".freeze
   LF_JSON_NO_BIN = "json_drop_binary".freeze
   LF_PLAIN = "plain".freeze
   LF_JSON_BIN_AS_TEXT = "json_binary_as_text".freeze
+  LF_EXTENDED = "extended".freeze
   VT_KEYS_ONLY = "keys_only".freeze
   VT_OLD_IMAGE = "old_image".freeze
   VT_NEW_IMAGE = "new_image".freeze
@@ -124,7 +125,7 @@ class LogStash::Inputs::DynamoDB < LogStash::Inputs::Base
     # For more information see: docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataFormat.html
   # json_drop_binary will return just the data specified in the view_format in JSON while not including any binary values that were present.
   # json_binary_as_text will return just the data specified in the view_format in JSON while including binary values as base64-encoded text.
-  config :log_format, :validate => [LF_PLAIN, LF_DYNAMODB, LF_JSON_NO_BIN, LF_JSON_BIN_AS_TEXT], :default => "plain"
+  config :log_format, :validate => [LF_PLAIN, LF_DYNAMODB, LF_JSON_NO_BIN, LF_JSON_BIN_AS_TEXT, LF_EXTENDED], :default => "plain"
 
   public
   def build_credentials

--- a/lib/logstash/inputs/dynamodb.rb
+++ b/lib/logstash/inputs/dynamodb.rb
@@ -174,7 +174,7 @@ class LogStash::Inputs::DynamoDB < LogStash::Inputs::Base
     end
     region = RegionUtils.getRegionByEndpoint(@endpoint)
 
-    @parser ||= Logstash::Inputs::DynamoDB::DynamoDBLogParser.new(@view_type, @log_format, @key_schema, region)
+    @parser ||= Logstash::Inputs::DynamoDB::DynamoDBLogParser.new(@view_type, @log_format, @key_schema, region, @table_name)
 
     if @perform_stream
       setup_stream


### PR DESCRIPTION
Add support for a JSON format that support all of "keys", "newImage" and "oldImage" if they are defined, plus the eventName and other metadata fields.

Fixes typos and incompatibility between NEW_IMAGE and REMOVE events.