### PR TITLE
Improve ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ git clone https://github.com/awslabs/logstash-input-dynamodb.git
 
 **Install the Bundler gem by typing the following:**
 
+Naviagte to the git project you just cloned and then run the following command:
+
 ```
 jruby -S gem install bundler
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://github.com/awslabs/logstash-input-dynamodb.git
 
 **Install the Bundler gem by typing the following:**
 
-Naviagte to the git project you just cloned and then run the following command:
+Navigate to the git project you just cloned and then run the following command:
 
 ```
 jruby -S gem install bundler


### PR DESCRIPTION
Make it obvious to the reader that they must be in the cloned repo before running jruby commands
